### PR TITLE
Support Mac OS X build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -30,7 +30,11 @@ if not conf.CheckPKG('sdl2'):
 env = conf.Finish()
 
 env.Append(CPPPATH = ['#src/includes/', '#src/engine/'])
-env.Append(LIBS = ['-lSDL2_mixer', '-lvorbisfile', '-lGL', '-lGLU'])
+env.Append(LIBS = ['-lSDL2_mixer', '-lvorbisfile'])
+if env['PLATFORM'] == 'darwin':
+    env.Append(FRAMEWORKS = ['OpenGL'])
+else:
+    env.Append(LIBS = ['-lGL', '-GLu'])
 env.Append(CFLAGS = ['-g'])
 env.Append(LINKFLAGS = ['-g'])
 env.Append(CPPDEFINES={'VERSION_MAJOR' : '3'})

--- a/src/SConscript
+++ b/src/SConscript
@@ -49,11 +49,16 @@ engine_sources = [
 	'engine/trans_fx.c'
 ]
 
-if env['PLATFORM'] in ('posix', 'linux', 'freebsd', 'darwin'):
+if env['PLATFORM'] in ('posix', 'linux', 'freebsd'):
 	main_sources += [
 		'osd_linux_cd.c',
 		'osd_keyboard.c',
 	]
+elif env['PLATFORM'] in ('darwin'):
+   main_sources += [
+       'osd_dummy_cd.c',
+       'osd_keyboard.c',
+   ]
 elif env['PLATFORM'] in ('haiku'):
 	main_sources += [
 		'osd_haiku_cd.c',

--- a/src/engine/lsmp3.c
+++ b/src/engine/lsmp3.c
@@ -40,7 +40,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <ctype.h>
-#if defined(__linux__)
+#if defined(__linux__) || defined(__APPLE__)
 #include <limits.h>
 #endif
 #include <assert.h>

--- a/src/engine/pce.h
+++ b/src/engine/pce.h
@@ -4,7 +4,7 @@
 
 #include "config.h"
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__APPLE__)
 #include <limits.h>
 #endif
 

--- a/src/engine/romdb.c
+++ b/src/engine/romdb.c
@@ -9,7 +9,7 @@
 
 #include "romdb.h"
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__APPLE__)
 #include <limits.h>
 #endif
 #include <stdlib.h>

--- a/src/includes/osd_sdl_gfx.h
+++ b/src/includes/osd_sdl_gfx.h
@@ -6,7 +6,11 @@
 
 #include <SDL.h>
 #include <SDL_endian.h>
+#if defined(__APPLE__)
+#include <OpenGL/glu.h>
+#else
 #include <GL/glu.h>
+#endif
 
 extern uchar *OSD_MESSAGE_SPR;
 

--- a/src/osd_sdl_gfx.c
+++ b/src/osd_sdl_gfx.c
@@ -371,7 +371,9 @@ osd_gfx_glinit(struct generic_rect* viewport)
 	glDisable(GL_ALPHA_TEST);
 	glDisable(GL_BLEND);
 	glDisable(GL_LIGHTING);
+#if !defined(__APPLE__)
 	glDisable(GL_TEXTURE_3D_EXT);
+#endif
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
 


### PR DESCRIPTION
Here is a small set of changes that could make huexpress run on Mac OS X with libraries built with [Homebrew](http://brew.sh/). Not heavily tested, but at least several games worked nicely on 10.10.

- Use bundled `OpenGL.framework`
  - `OpenGL/` instead of `GL/` for headers
  - `GL_TEXTURE_3D_EXT` commented out (somehow didn't get recognized)
- Use native `limits.h`
- Use `osd_dummy_cd` instead of `osd_linux_cd` due to missing `linux/cdrom.h`